### PR TITLE
Distroless docker run stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Cargo.lock Cargo.toml ./
 COPY src src/
 RUN cargo build --release
 
-FROM debian:11.7-slim
+FROM gcr.io/distroless/cc
 RUN addgroup --system rustapp \
     && adduser --system --ingroup rustapp rustapp
 USER rustapp

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,11 +9,9 @@ COPY src src/
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc
-RUN addgroup --system rustapp \
-    && adduser --system --ingroup rustapp rustapp
-USER rustapp
+USER nobody
 
 WORKDIR /app
-COPY --from=rust-build-stage --chown=rustapp:rustapp /build/target/release/factorio-printer .
+COPY --from=rust-build-stage --chown=nobody:nogroup /build/target/release/factorio-printer .
 
 ENTRYPOINT ["/app/factorio-printer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ COPY src src/
 RUN cargo build --release
 
 FROM gcr.io/distroless/cc-debian10
-USER nobody
+USER 1001:1001
 
 WORKDIR /app
-COPY --from=rust-build-stage --chown=nobody:nogroup /build/target/release/factorio-printer .
+COPY --from=rust-build-stage --chown=1001:1001 /build/target/release/factorio-printer .
 
 ENTRYPOINT ["/app/factorio-printer"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Cargo.lock Cargo.toml ./
 COPY src src/
 RUN cargo build --release
 
-FROM gcr.io/distroless/cc@sha256:f81e5db8287d66b012d874a6f7fea8da5b96d9cc509aa5a9b5d095a604d4bca1
+FROM gcr.io/distroless/cc-debian10
 USER nobody
 
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY Cargo.lock Cargo.toml ./
 COPY src src/
 RUN cargo build --release
 
-FROM gcr.io/distroless/cc
+FROM gcr.io/distroless/cc@sha256:f81e5db8287d66b012d874a6f7fea8da5b96d9cc509aa5a9b5d095a604d4bca1
 USER nobody
 
 WORKDIR /app


### PR DESCRIPTION
Nice catch! I definitely picked the wrong base image for the run stage. 2GB, yuck!

This is only a marginal gain over your improvement in cca30c0315e4020a2408390548c53d013f5aabe4,
but on my system this PR reduces the image size from ~86Mb to ~23Mb. For what that's
worth.
